### PR TITLE
Fixed fw update with long filenames

### DIFF
--- a/dronecan_gui_tool/widgets/node_properties.py
+++ b/dronecan_gui_tool/widgets/node_properties.py
@@ -17,6 +17,7 @@ from PyQt5.QtGui import QPalette
 from logging import getLogger
 from . import get_monospace_font, make_icon_button, BasicTable, show_error, request_confirmation
 from .node_monitor import node_health_to_color, node_mode_to_color
+from .file_server import FileServer_PathKey
 
 
 logger = getLogger(__name__)
@@ -277,7 +278,7 @@ class Controls(QGroupBox):
             show_error('File server error', 'Could not configure the file server', ex, self)
             return
 
-        remote_fw_file = os.path.basename(fw_file)
+        remote_fw_file = FileServer_PathKey(fw_file)
         logger.info('Firmware file remote path: %r', remote_fw_file)
 
         deferred_request_handle = None

--- a/dronecan_gui_tool/widgets/node_properties.py
+++ b/dronecan_gui_tool/widgets/node_properties.py
@@ -243,16 +243,6 @@ class Controls(QGroupBox):
                        'Assign a node ID to the local node in order to issue requests (see the main window)', self)
             return
 
-        # Checking if the dynamic node ID allocator is running; warning the user if it doesn't
-        if self._dynamic_node_id_allocator_widget.allocator is None:
-            if not request_confirmation('Suspicious configuration',
-                                        'The local dynamic node ID allocator is not running (see the main window).\n'
-                                        'Some nodes will not be able to perform firmware update unless a dynamic node '
-                                        'ID allocator is available on the bus.\n'
-                                        'Do you want to continue anyway?', self):
-                self.window().show_message('Cancelled')
-                return
-
         # Requesting the firmware path
         fw_file = QFileDialog().getOpenFileName(self, 'Select firmware file', '',
                                                 'Binary images (*.bin);;ArduPilot Firmware (*.apj);;PX4 Firmware (*.px4);;All files (*.*)')


### PR DESCRIPTION
use a crc32 to get a key, making update more reliable
also fixes a problem with loading the same name from different directories and getting the wrong file
