### PR TITLE
Add PCAN support through python-can

### DIFF
--- a/dronecan_gui_tool/setup_window.py
+++ b/dronecan_gui_tool/setup_window.py
@@ -105,6 +105,14 @@ def list_ifaces():
         for x in mifaces:
             out[x] = x
 
+        try:
+            from can import detect_available_configs
+            for interface in detect_available_configs():
+                if interface['interface'] == "pcan":
+                    out[interface['channel']] = interface['channel']
+        except Exception as ex:
+            logger.warning('Could not load can interfaces: %s', ex, exc_info=True)
+
         return out
 
 

--- a/winbuild.bat
+++ b/winbuild.bat
@@ -18,6 +18,7 @@ python --version
 python -m pip install -U cx_Freeze
 python -m pip install -U pymavlink
 python -m pip install -U pywin32
+python -m pip install -U python-can
 python -m pip install -U .
 
 rem show pip sizes for debug


### PR DESCRIPTION
Depends on dronecan/pydronecan#25

Iterates python-can compatible PCAN interfaces and adds to them to ifaces list.

Tested on Windows.