### PR TITLE
widgets/node_properties: increase timeout to 5s for param erase opcode

### DIFF
--- a/dronecan_gui_tool/widgets/node_properties.py
+++ b/dronecan_gui_tool/widgets/node_properties.py
@@ -749,7 +749,7 @@ class ConfigParams(QGroupBox):
                 self.window().show_message('Opcode execution response for %s: %s', opcode_str, e.response)
 
         try:
-            self._node.request(request, self._target_node_id, callback, priority=REQUEST_PRIORITY)
+            self._node.request(request, self._target_node_id, callback, priority=REQUEST_PRIORITY, timeout=5000.0)
             self.window().show_message('Param opcode %s requested', opcode_str)
         except Exception as ex:
             show_error('Node error', 'Could not send param opcode execution request', ex, self)


### PR DESCRIPTION
* default timeout is not long enough for erase opcode to finish successfully on AP_Periph