### PR TITLE
fix number type error in esc pannel

### DIFF
--- a/dronecan_gui_tool/panels/esc_panel.py
+++ b/dronecan_gui_tool/panels/esc_panel.py
@@ -94,7 +94,7 @@ class ESCPanel(QDialog):
         self._bcast_interval.setSingleStep(0.1)
         self._bcast_interval.setValue(self.DEFAULT_INTERVAL)
         self._bcast_interval.valueChanged.connect(
-            lambda: self._bcast_timer.setInterval(self._bcast_interval.value() * 1e3))
+            lambda: self._bcast_timer.setInterval(int(self._bcast_interval.value() * 1e3)))
 
         self._stop_all = make_icon_button('hand-stop-o', 'Zero all channels', self, text='Stop All',
                                           on_clicked=self._do_stop_all)


### PR DESCRIPTION
fix input float number that raised error
```shell
  File "****/gui_tool/dronecan_gui_tool/panels/esc_panel.py", line 97, in <lambda>
    lambda: self._bcast_timer.setInterval(self._bcast_interval.value() * 1e3))
TypeError: setInterval(self, int): argument 1 has unexpected type 'float'
```
![WeChata0f67b9d8fc13449dfa1c968f8eb0339](https://github.com/user-attachments/assets/ec2f25a8-ca85-47ac-8fac-ece1555ff36e)
![WeChatf6f4d599032a95e12777186d78080723](https://github.com/user-attachments/assets/89301ef3-a9e7-406a-b35b-19bd8eb6d225)
