### PR TITLE
fix esc status label update after pannel close

### DIFF
--- a/dronecan_gui_tool/panels/esc_panel.py
+++ b/dronecan_gui_tool/panels/esc_panel.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QLabel, QDialog, 
 from PyQt5.QtCore import QTimer, Qt
 from logging import getLogger
 from ..widgets import make_icon_button, get_icon, get_monospace_font
+import sip
 
 __all__ = 'PANEL_NAME', 'spawn', 'get_icon'
 
@@ -176,7 +177,8 @@ class ESCPanel(QDialog):
     def _on_esc_status(self, msg):
         if msg.message.esc_index < len(self._sliders):
             sl = self._sliders[msg.message.esc_index] 
-            sl.update_status(msg) 
+            if sl and not sip.isdeleted(sl):
+                sl.update_status(msg)
 
     def _do_broadcast(self):
         try:


### PR DESCRIPTION
avoid update function call after pannel close
```
2024-11-11 14:48:17,410 ERROR dronecan.node Transfer handler exception
Traceback (most recent call last):
  File "/home/parallels/.local/lib/python3.12/site-packages/dronecan/node.py", line 198, in call_handlers
    wrapper(transfer)
  File "/home/parallels/.local/lib/python3.12/site-packages/dronecan/node.py", line 171, in call
    result = handler(event, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/dronecan_gui_tool/panels/esc_panel.py", line 179, in _on_esc_status
    sl.update_status(msg)
  File "/usr/local/lib/python3.12/dist-packages/dronecan_gui_tool/panels/esc_panel.py", line 87, in update_status
    self._error_count_label.setText(f'Err: {status.error_count}')
RuntimeError: wrapped C/C++ object of type QLabel has been deleted
```