### PR TITLE
esc_panel: allow height to be auto-adjusted

### DIFF
--- a/dronecan_gui_tool/panels/esc_panel.py
+++ b/dronecan_gui_tool/panels/esc_panel.py
@@ -75,8 +75,6 @@ class PercentSlider(QWidget):
 
         self.setLayout(layout)
 
-        self.setMinimumHeight(300)
-
     def zero(self):
         self._slider.setValue(0)
 


### PR DESCRIPTION
Avoids needing to resize the window to see telemetry fields on a HiDPI screen.

Before:
![Screenshot from 2024-12-15 16-11-19](https://github.com/user-attachments/assets/dd9bcc07-dab5-4a19-9a60-f52c0abe2b21)

After:
![Screenshot from 2024-12-15 16-15-59](https://github.com/user-attachments/assets/c6276475-b940-47c8-be6e-f54ce0db1490)
