### PR TITLE
.github: use latest actions/upload-artifact instead of disabled version

### DIFF
--- a/.github/workflows/winbuild.yml
+++ b/.github/workflows/winbuild.yml
@@ -41,7 +41,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-artifact
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: MSI Package
         path: dist


### PR DESCRIPTION
Fixes CI failure.