### PR TITLE
fixed problem with pywintypes.com_error

### DIFF
--- a/dronecan_gui_tool/setup_window.py
+++ b/dronecan_gui_tool/setup_window.py
@@ -115,6 +115,8 @@ def list_ifaces():
 
         try:
             from can import detect_available_configs
+            import pythoncom
+            pythoncom.CoInitialize()
             for interface in detect_available_configs():
                 if interface['interface'] == "pcan":
                     out[interface['channel']] = interface['channel']


### PR DESCRIPTION
Important fix to gui_tool not beeing able to detect PCAN (and other interfaces) on windows:
pywintypes.com_error: (-2147221020, 'Nieprawidłowa składnia.', None, None)

Error happens when method detect_available_configs() is executed. It happens when periodic scan of interfaces takes place. 

Fix for common error in windows:
https://stackoverflow.com/questions/38860185/python-cant-import-wmi-under-special-circumstance

**Platform: win10**

```
2025-03-21 21:22:52,885 WARNING dronecan_gui_tool.setup_window Could not load can interfaces: (-2147221020, 'Nieprawidłowa składnia.', None, None)
Traceback (most recent call last):
  File "D:\setup_window.py", line 120, in list_ifaces
    for interface in detect_available_configs():
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\can\interface.py", line 183, in detect_available_configs
    bus_class._detect_available_configs()  # pylint: disable=protected-access
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\can\interfaces\usb2can\usb2canInterface.py", line 207, in _detect_available_configs
    return Usb2canBus.detect_available_configs()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\can\interfaces\usb2can\usb2canInterface.py", line 218, in detect_available_configs
    channels = find_serial_devices()
               ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\can\interfaces\usb2can\serial_selector.py", line 55, in find_serial_devices
    wmi = win32com.client.GetObject("winmgmts:")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\win32com\client\__init__.py", line 86, in GetObject
    return Moniker(Pathname, clsctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python312\Lib\site-packages\win32com\client\__init__.py", line 103, in Moniker
    moniker, i, bindCtx = pythoncom.MkParseDisplayName(Pathname)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pywintypes.com_error: (-2147221020, 'Nieprawidłowa składnia.', None, None)
```