### PR TITLE
main: set local node icon becomes hand

### DIFF
--- a/dronecan_gui_tool/widgets/local_node.py
+++ b/dronecan_gui_tool/widgets/local_node.py
@@ -56,7 +56,7 @@ class LocalNodeWidget(QGroupBox):
         self._node_id_spinbox.setValue(NODE_ID_MAX)
         self._node_id_spinbox.valueChanged.connect(self._update)
 
-        self._node_id_apply = make_icon_button('fa6s.check', 'Apply local node ID', self,
+        self._node_id_apply = make_icon_button('fa6s.hand', 'Apply local node ID', self, text='Set',
                                                on_clicked=self._on_node_id_apply_clicked)
 
         self._update_timer = QTimer(self)


### PR DESCRIPTION
This replaces the icon to the right of the "Set local node ID".  Currently it is a checkbox but after this change it becomes a "hand" with the word "Set" to the right of it.

A checkbox is normally for turning an option on/off but in this case what we really want is more of a button.  Using the "hand" icon is consistent with other pages like the "ESC MAnagement Panel"

I must admit that I haven't actually figured out how to build and run this change so it's untested but I still suspect the change works.  If someone could give me a bit of advice on how to build and test I'd be overjoyed to test this important change :-)