### PR TITLE
gui: fixes a forever loop when a malformed interface is specified

### DIFF
--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -653,6 +653,10 @@ def main():
         except Exception as ex:
             logger.error('DroneCAN node init failed', exc_info=True)
             show_error('Fatal error', 'Could not initialize DroneCAN node', ex, blocking=True)
+
+            # An exception occurred, so reset args and the interface and return to the setup window
+            args.interface = None
+            iface = None
         else:
             break
 


### PR DESCRIPTION
If you used an argument that results in the device failing  to open (eg `--interface aaaa`), it falls through to `Exception`.
If the exception occurs, you can result in a forever loop where a non-serial interface was set at the command line, but the device fails to open.

If an exception occurs, force a return to the setup window, with cleared iface and args.