### PR TITLE
gui: Add support for loading external installed modules

### DIFF
--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -83,6 +83,7 @@ if multiprocessing.get_start_method(True) != 'spawn':
 #
 # Importing other stuff once the logging has been configured
 #
+from pathlib import Path
 from serial import SerialException
 
 import dronecan
@@ -112,6 +113,14 @@ from .widgets.can_adapter_control_panel import spawn_window as spawn_can_adapter
 
 from .panels import PANELS
 from .panels import import_panel
+
+# Add the User ~/dronecan_gui_tool/plugins folder to the import path,
+# allowing for custom plugin modules to be loaded from there.
+plugins_dir = Path.home() / "dronecan_gui_tool" / "plugins"
+if plugins_dir.exists():
+    str_plugin_dir = str(plugins_dir)
+    if str_plugin_dir not in sys.path:
+        sys.path.insert(0, str_plugin_dir)
 
 EXT_PLUGINS = []
 modules = args.load_module[0] if args.load_module else []

--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -15,6 +15,12 @@ import tempfile
 
 assert sys.version[0] == '3'
 
+def parse_load_modules(argv):
+    modules = [m.strip() for m in argv.split(",") if m.strip()]
+    if not modules:
+        return None
+    return modules
+
 from argparse import ArgumentParser
 parser = ArgumentParser(description='DroneCAN GUI tool')
 
@@ -29,6 +35,8 @@ parser.add_argument("--bus", help="set the CAN Bus number", type=int, default=1)
 parser.add_argument("--filtered", action='store_true', help="enable filtering of DroneCAN traffic")
 parser.add_argument("--target-system", help="set the targetted system", type=int, default=0)
 parser.add_argument("--source-system", help="set the source system", type=int, default=250)
+
+parser.add_argument("--load-module", type=parse_load_modules, nargs=1,  help="Comma-separated list of modules to load (e.g. mod1,mod2).") # exactly one argument required if flag is present
 
 args = parser.parse_args()
 
@@ -103,7 +111,18 @@ from .widgets.about_window import AboutWindow
 from .widgets.can_adapter_control_panel import spawn_window as spawn_can_adapter_control_panel
 
 from .panels import PANELS
+from .panels import import_panel
 
+EXT_PLUGINS = []
+modules = args.load_module[0] if args.load_module else []
+if len(modules) > 0:
+    for module in modules:
+        try:
+            panel = import_panel(module)
+            EXT_PLUGINS.append(panel)
+        except Exception as ex:
+            print(f"Unable to load {module}: {ex}")
+    print(f"Loaded {len(EXT_PLUGINS)} plugin modules!")
 
 NODE_NAME = 'org.dronecan.gui_tool'
 
@@ -211,6 +230,39 @@ class MainWindow(QMainWindow):
                 action.setShortcut(QKeySequence('Ctrl+Shift+%d' % (idx + 1)))
             action.triggered.connect(lambda state, panel=panel: panel.safe_spawn(self, self._node))
             panels_menu.addAction(action)
+
+        #
+        # External Modules menu
+        #
+        def get_or_create_submenu(parent_menu, menu_name):
+            """
+            Find a submenu with menu_name under parent_menu, or create it if not found.
+            """
+            for action in parent_menu.actions():
+                submenu = action.menu()
+                if submenu and submenu.title() == menu_name:
+                    return submenu
+            # Not found, create new submenu
+            return parent_menu.addMenu(menu_name)
+
+        if len(EXT_PLUGINS) > 0:
+            extern_modules_menu = self.menuBar().addMenu('P&lugins')
+            for idx, panel in enumerate(EXT_PLUGINS):
+                menu_path = getattr(panel, "menu_path", "")
+                path_parts = [p for p in menu_path.split("/") if p]
+
+                current_menu = extern_modules_menu
+                for part in path_parts:
+                    current_menu = get_or_create_submenu(current_menu, part)
+
+                action = QAction(panel.name, self)
+                icon = panel.get_icon()
+                if icon:
+                    action.setIcon(icon)
+                if idx < 9:
+                    action.setShortcut(QKeySequence(f'Ctrl+Shift+[,{(idx + 1)}'))
+                action.triggered.connect(lambda state, panel=panel: panel.safe_spawn(self, self._node))
+                current_menu.addAction(action)
 
         #
         # Help menu

--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -15,6 +15,9 @@ import tempfile
 
 assert sys.version[0] == '3'
 
+def parse_load_modules(value):
+    return [m.strip() for m in value.split(",") if m.strip()]
+
 from argparse import ArgumentParser
 parser = ArgumentParser(description='DroneCAN GUI tool')
 
@@ -29,6 +32,8 @@ parser.add_argument("--bus", help="set the CAN Bus number", type=int, default=1)
 parser.add_argument("--filtered", action='store_true', help="enable filtering of DroneCAN traffic")
 parser.add_argument("--target-system", help="set the targetted system", type=int, default=0)
 parser.add_argument("--source-system", help="set the source system", type=int, default=250)
+
+parser.add_argument("--load-module", type=parse_load_modules, nargs=1,  help="Comma-separated list of modules to load (e.g. mod1,mod2).") # exactly one argument required if flag is present
 
 args = parser.parse_args()
 
@@ -103,7 +108,18 @@ from .widgets.about_window import AboutWindow
 from .widgets.can_adapter_control_panel import spawn_window as spawn_can_adapter_control_panel
 
 from .panels import PANELS
+from .panels import import_panel
 
+EXT_PLUGINS = []
+modules = args.load_module[0] if args.load_module else []
+if len(modules) > 0:
+    for module in modules:
+        try:
+            panel = import_panel(module)
+            EXT_PLUGINS.append(panel)
+        except Exception as ex:
+            logger.error(f"Unable to load {module}: {ex}")
+    logger.info(f"Loaded {len(EXT_PLUGINS)} plugin modules!")
 
 NODE_NAME = 'org.dronecan.gui_tool'
 
@@ -211,6 +227,39 @@ class MainWindow(QMainWindow):
                 action.setShortcut(QKeySequence('Ctrl+Shift+%d' % (idx + 1)))
             action.triggered.connect(lambda state, panel=panel: panel.safe_spawn(self, self._node))
             panels_menu.addAction(action)
+
+        #
+        # External Modules menu
+        #
+        def get_or_create_submenu(parent_menu, menu_name):
+            """
+            Find a submenu with menu_name under parent_menu, or create it if not found.
+            """
+            for action in parent_menu.actions():
+                submenu = action.menu()
+                if submenu and submenu.title() == menu_name:
+                    return submenu
+            # Not found, create new submenu
+            return parent_menu.addMenu(menu_name)
+
+        if len(EXT_PLUGINS) > 0:
+            extern_modules_menu = self.menuBar().addMenu('P&lugins')
+            for idx, panel in enumerate(EXT_PLUGINS):
+                menu_path = getattr(panel, "menu_path", "")
+                path_parts = [p for p in menu_path.split("/") if p]
+
+                current_menu = extern_modules_menu
+                for part in path_parts:
+                    current_menu = get_or_create_submenu(current_menu, part)
+
+                action = QAction(panel.name, self)
+                icon = panel.get_icon()
+                if icon:
+                    action.setIcon(icon)
+                if idx < 9:
+                    action.setShortcut(QKeySequence(f'Ctrl+Shift+[,{(idx + 1)}'))
+                action.triggered.connect(lambda state, panel=panel: panel.safe_spawn(self, self._node))
+                current_menu.addAction(action)
 
         #
         # Help menu

--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -80,6 +80,7 @@ if multiprocessing.get_start_method(allow_none=True) is None:
 #
 # Importing other stuff once the logging has been configured
 #
+from pathlib import Path
 from serial import SerialException
 
 import dronecan
@@ -109,6 +110,14 @@ from .widgets.can_adapter_control_panel import spawn_window as spawn_can_adapter
 
 from .panels import PANELS
 from .panels import import_panel
+
+# Add the User ~/dronecan_gui_tool/plugins folder to the import path,
+# allowing for custom plugin modules to be loaded from there.
+plugins_dir = Path.home() / "dronecan_gui_tool" / "plugins"
+if plugins_dir.exists():
+    str_plugin_dir = str(plugins_dir)
+    if str_plugin_dir not in sys.path:
+        sys.path.insert(0, str_plugin_dir)
 
 EXT_PLUGINS = []
 modules = args.load_module[0] if args.load_module else []

--- a/dronecan_gui_tool/panels/__init__.py
+++ b/dronecan_gui_tool/panels/__init__.py
@@ -18,6 +18,8 @@ from . import RemoteID_panel
 from . import hobbywing_esc
 from . import rc_panel
 
+import importlib.util
+
 class PanelDescriptor:
     def __init__(self, module):
         self.name = module.PANEL_NAME
@@ -36,6 +38,23 @@ class PanelDescriptor:
         except Exception as ex:
             show_error('Panel error', 'Could not spawn panel', ex)
 
+def import_panel(name):
+    """Given a package name like 'foo.bar.quux', imports the package
+    and returns the desired module."""
+    spec = importlib.util.find_spec(name)
+    mod = None
+    if spec is None:
+        raise Exception(f"Module '{name}' not found!")
+    else:
+        mod = importlib.import_module(name)
+        print(f"Successfully imported {name} from {mod.__file__}")
+    return PluginPanelDescriptor(mod)
+
+class PluginPanelDescriptor(PanelDescriptor):
+    def __init__(self, module):
+        super().__init__(module)
+
+        self.menu_path = getattr(module, "MENU_PATH", "")
 
 PANELS = [
     PanelDescriptor(esc_panel),

--- a/dronecan_gui_tool/panels/__init__.py
+++ b/dronecan_gui_tool/panels/__init__.py
@@ -20,6 +20,9 @@ from . import rc_panel
 from . import hardpoints_panel
 from . import circuit_status_panel
 
+import importlib
+import importlib.util
+
 class PanelDescriptor:
     def __init__(self, module):
         self.name = module.PANEL_NAME
@@ -38,6 +41,23 @@ class PanelDescriptor:
         except Exception as ex:
             show_error('Panel error', 'Could not spawn panel', ex)
 
+def import_panel(name):
+    """Given a package name like 'foo.bar.quux', imports the package
+    and returns the desired module."""
+    spec = importlib.util.find_spec(name)
+    mod = None
+    if spec is None:
+        raise Exception(f"Module '{name}' not found!")
+    else:
+        mod = importlib.import_module(name)
+        print(f"Successfully imported {name} from {mod.__file__}")
+    return PluginPanelDescriptor(mod)
+
+class PluginPanelDescriptor(PanelDescriptor):
+    def __init__(self, module):
+        super().__init__(module)
+
+        self.menu_path = getattr(module, "MENU_PATH", "")
 
 PANELS = [
     PanelDescriptor(esc_panel),


### PR DESCRIPTION
I've been using a modified version of this for some time now.

It borrows from the idea that a user could extend the interface to provide their own functionality.

The most basic of plugin modules looks like so:

```python

import dronecan
from PyQt6.QtWidgets import QVBoxLayout, QWidget, QLabel, QDialog, QPlainTextEdit
from PyQt6.QtCore import Qt
from logging import getLogger

__all__ = 'PANEL_NAME', 'spawn', 'get_icon'

PANEL_NAME = 'Custom Panel'

logger = getLogger(__name__)

_singleton = None

class CustomPanel(QDialog):
    def __init__(self, parent, node):
        super(CustomPanel, self).__init__(parent)
        self.setWindowTitle('My Custom Panel')
        self.setAttribute(Qt.WA_DeleteOnClose)

        self._node = node

        layout = QVBoxLayout(self)
        layout.addWidget(QLabel('This is a label!', self))
        self.setLayout(layout)

    def closeEvent(self, event):
        global _singleton
        _singleton = None
        super(CustomPanel, self).closeEvent(event)

def spawn(parent, node):
    global _singleton
    if _singleton is None:
        _singleton = CustomPanel(parent, node)

    _singleton.show()
    _singleton.raise_()
    _singleton.activateWindow()

    return _singleton

def get_icon():
    return None

```

These modules can then be distributed as wheels and loaded by the user when required.