### PR TITLE
Fix icon name typo

### DIFF
--- a/dronecan_gui_tool/widgets/can_adapter_control_panel/slcan_cli.py
+++ b/dronecan_gui_tool/widgets/can_adapter_control_panel/slcan_cli.py
@@ -281,7 +281,7 @@ class ConfigWidget(QWidget):
 
         self._have_unsaved_changes = False
 
-        self._fetch_button = make_icon_button('fa6s.arrows-roatate',
+        self._fetch_button = make_icon_button('fa6s.arrows-rotate',
                                               'Fetch configuration from the adapter',
                                               self, on_clicked=self._do_fetch, text='Fetch')
 


### PR DESCRIPTION
Fixes a typo in the icon name, which causes a crash when the "CAN Adapter Control Panel" tool is started.