### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/dronecan_gui_tool/widgets/__init__.py
+++ b/dronecan_gui_tool/widgets/__init__.py
@@ -9,7 +9,7 @@
 import os
 import re
 import queue
-from importlib.resources import as_file, files
+import importlib.resources
 from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView, QApplication, QWidget, \
     QComboBox, QCompleter, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox
 from PyQt5.QtCore import Qt, QTimer, QStringListModel
@@ -640,8 +640,8 @@ def get_app_icon():
         pass
     # noinspection PyBroadException
     try:
-        icon_resource = files('dronecan_gui_tool').joinpath('icons', 'dronecan_gui_tool.png')
-        with as_file(icon_resource) as icon_path:
+        icon_resource = importlib.resources.files('dronecan_gui_tool').joinpath('icons', 'dronecan_gui_tool.png')
+        with importlib.resources.as_file(icon_resource) as icon_path:
             _APP_ICON_OBJECT = QIcon(str(icon_path))
     except Exception:
         logger.error('Could not load icon', exc_info=True)

--- a/pip_sizes.py
+++ b/pip_sizes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from importlib import metadata
+import importlib
 
 def calc_container(path):
     total_size = 0
@@ -13,7 +13,7 @@ def calc_container(path):
 
 
 
-dists = list(metadata.distributions())
+dists = list(importlib.metadata.distributions())
 
 data = {}
 data2 = []

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import sys
 import shutil
 import glob
-from importlib import metadata
+import importlib
 from setuptools import setup, find_packages
 from setuptools.archive_util import unpack_archive
 
@@ -131,8 +131,8 @@ if ('bdist_msi' in sys.argv) or ('build_exe' in sys.argv):
         pass
     for dep in dependency_eggs_to_unpack:
         try:
-            dist = metadata.distribution(dep)
-        except metadata.PackageNotFoundError:
+            dist = importlib.metadata.distribution(dep)
+        except importlib.metadata.PackageNotFoundError:
             continue
         dist_location = str(dist.locate_file(''))
         if not os.path.isdir(dist_location):


### PR DESCRIPTION
dronecan_gui_tool cannot be installed on systems with python 3.12+, because dependency pkg_resources was removed. In this PR, I replaced pkg_resources with importlib, following the migration guide:

https://importlib-resources.readthedocs.io/en/latest/migration.html

This fulfills the same purpose as PR https://github.com/dronecan/gui_tool/pull/114

and solves issue https://github.com/dronecan/gui_tool/issues/113

Tested on Ubuntu 24.04