### PR TITLE
ui: Migrate CheckBoxes to use binary state functions setChecked/isChecked

### DIFF
--- a/dronecan_gui_tool/panels/esc_panel.py
+++ b/dronecan_gui_tool/panels/esc_panel.py
@@ -314,11 +314,11 @@ class ESCPanel(QDialog):
                 sl.check_fps_timeout()
             if not self._view_mode.isChecked():
                 if not self._pause.isChecked():
-                    if self._safety_enable.checkState():
+                    if self._safety_enable.isChecked():
                         msg = dronecan.ardupilot.indication.SafetyState()
                         msg.status = msg.STATUS_SAFETY_OFF
                         self._node.broadcast(msg)
-                    if self._arming_enable.checkState():
+                    if self._arming_enable.isChecked():
                         msg = dronecan.uavcan.equipment.safety.ArmingStatus()
                         msg.status = msg.STATUS_FULLY_ARMED
                         self._node.broadcast(msg)

--- a/dronecan_gui_tool/panels/serial_panel.py
+++ b/dronecan_gui_tool/panels/serial_panel.py
@@ -486,7 +486,7 @@ class serialPanel(QDialog):
 
     def handle_ublox_data_out(self, buf):
         '''handle ublox data from the GPS'''
-        if not self.ublox_handling.checkState():
+        if not self.ublox_handling.isChecked():
             self.ublox_msg_out = None
             return
         if self.ublox_msg_out is None:
@@ -565,7 +565,7 @@ class serialPanel(QDialog):
 
             if buf is None or len(buf) == 0:
                 break
-            if self.ublox_handling.checkState():
+            if self.ublox_handling.isChecked():
                 # we will send the data on packet boundaries
                 self.handle_ublox_data_in(buf)
             else:

--- a/dronecan_gui_tool/setup_window.py
+++ b/dronecan_gui_tool/setup_window.py
@@ -274,7 +274,7 @@ def run_setup_window(icon, dsdl_path=None, config_baudrate=DEFAULT_BAUD_RATE, co
         kwargs['baudrate'] = baud_rate_value
         kwargs['bitrate'] = int(bitrate.value())
         kwargs['bus_number'] = int(bus_number.value())
-        kwargs['filtered'] = filtered.checkState()
+        kwargs['filtered'] = filtered.isChecked()
         kwargs['mavlink_source_system'] = int(source_system.value())
         kwargs['mavlink_target_system'] = int(target_system.value())
         kwargs['mavlink_signing_key'] = signing_key.text()

--- a/dronecan_gui_tool/widgets/local_node.py
+++ b/dronecan_gui_tool/widgets/local_node.py
@@ -149,7 +149,7 @@ class AdapterSettingsWidget(QGroupBox):
             self._filtering.setTristate(False)
             filter_list = node.can_driver.get_filter_list()
             if filter_list is not None and len(filter_list) > 0:
-                self._filtering.setCheckState(2)
+                self._filtering.setChecked(True)
             self._filtering.stateChanged.connect(self.change_filtering)
 
         layout = QHBoxLayout(self)


### PR DESCRIPTION
Various points in the code make use of Tri-state functionality (ie. setCheckState()/checkState()).

In working to migrate the tool to PyQt6, the checkState() returns and enum, and the enum CheckedState.Unchecked is not considered Falsy.

What that means is `if chkbox.checkState()` always returns True.

The checkState functionality allows us to make use of a PartiallyChecked state, which is never used inside the codebase - so let's just use the binary states.

```python
# In PyQt6...
>>> from PyQt6.QtCore import Qt
>>> print(f"{bool(Qt.CheckState.Unchecked)=}")
bool(Qt.CheckState.Unchecked)=True
>>> print(f"{bool(Qt.CheckState.PartiallyChecked)=}")
bool(Qt.CheckState.PartiallyChecked)=True
>>> print(f"{bool(Qt.CheckState.Checked)=}")
bool(Qt.CheckState.Checked)=True
```

This differs from PyQt5 where:
```python
# In PyQt5...
>>> import PyQt5
>>> from PyQt5.QtCore import Qt
>>> print(f"{bool(Qt.CheckState.Unchecked)=}")
bool(Qt.CheckState.Unchecked)=False
>>> print(f"{bool(Qt.CheckState.PartiallyChecked)=}")
bool(Qt.CheckState.PartiallyChecked)=True
>>> print(f"{bool(Qt.CheckState.Checked)=}")
bool(Qt.CheckState.Checked)=True
```

Needed to resolve Issue #107 