### PR TITLE
tools: drop use of sudo when clearing build outputs

### DIFF
--- a/remove_build_outputs.sh
+++ b/remove_build_outputs.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo rm -rf build dronecan_gui_tool.* dist* *-*.egg
+rm -rf build dronecan_gui_tool.* dist* *-*.egg


### PR DESCRIPTION
We stopped suggesting installation/building with sudo relatively recently.

Building doesn't require sudo, so clearing the build outputs shouldn't use sudo either.