### PR TITLE
build: fixes broken line in winbuild.bat

### DIFF
--- a/pip_sizes.py
+++ b/pip_sizes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-import importlib
+import importlib.metadata
 
 def calc_container(path):
     total_size = 0


### PR DESCRIPTION
Starting at Python 3.8, importlib metadata was merged into python standard library as `importlib.metadata` module.

PR #115 replaced pkg_resources with importlib. Noticed when running under a new venv environment that we need to `import importlib.metadata` and not just `import importlib`. For some reason this behaviour was different on my systems python and only showed when running from the venv.

It's only run from windows build, and somewhat silently errors because the batch file continues when that line breaks.