### PR TITLE
gui: Set Style to Fusion for all systems

### DIFF
--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -591,6 +591,9 @@ def main():
     logger.info('Starting the application')
     app = QApplication(sys.argv)
 
+    # Set the style for Qt6 to be same across systems
+    app.setStyle("Fusion")
+
     while True:
         # Asking the user to specify which interface to work with
         try:


### PR DESCRIPTION
There was something uncanny with the windows build. 

You'll notice the windows before image looks different to the Linux before (I haven't added Linux before since it looks the same as Linux after).

The fusion style is platform agnostic, and should be same across systems. See: https://doc.qt.io/qt-6/qtquickcontrols-fusion.html


Windows before: 
<img width="800" height="436" alt="image" src="https://github.com/user-attachments/assets/de188a3e-f451-4889-97f1-412b758c184c" />

Windows after:
<img width="800" height="432" alt="image" src="https://github.com/user-attachments/assets/ad92501a-c055-4286-963a-1efdbe8c0f51" />


Linux after:
<img width="1266" height="669" alt="image" src="https://github.com/user-attachments/assets/c53ecd59-ccde-41d5-8608-143a06c191d7" />
