### PR TITLE
widgets: Ensure Bus Monitor and Plotter both spawn QApplication with Fusion Style enabled

### DIFF
--- a/dronecan_gui_tool/widgets/bus_monitor/__init__.py
+++ b/dronecan_gui_tool/widgets/bus_monitor/__init__.py
@@ -56,6 +56,9 @@ def _process_entry_point(channel, iface_name):
     logger.info('Bus monitor process started with PID %r', os.getpid())
     app = QApplication(sys.argv)    # Inheriting args from the parent process
 
+    # Set the style for Qt6 to be same across systems
+    app.setStyle("Fusion")
+
     def exit_if_should():
         if RUNNING_ON_WINDOWS:
             return False

--- a/dronecan_gui_tool/widgets/plotter/__init__.py
+++ b/dronecan_gui_tool/widgets/plotter/__init__.py
@@ -57,6 +57,9 @@ def _process_entry_point(channel):
     logger.info('Plotter process started with PID %r', os.getpid())
     app = QApplication(sys.argv)    # Inheriting args from the parent process
 
+    # Set the style for Qt6 to be same across systems
+    app.setStyle("Fusion")
+
     def exit_if_should():
         if RUNNING_ON_WINDOWS:
             return False


### PR DESCRIPTION
Opening Bus Monitor and Plotter open new QApplications which default to the system style - so this will ensure all QApplications that are spawned use the Fusion style