### PR TITLE
setup.py: Allow `dronecan_gui_tool` to be `pip install`ed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ args = dict(
     package_data={'DroneCAN_GUI_Tool': [ 'icons/*.png', 'icons/*.ico']}
 )
 
-if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+if 'install' in sys.argv and (sys.platform.startswith('linux') or sys.platform.startswith('darwin')):
     # Delegating the desktop integration work to 'install_freedesktop'
     args.setdefault('setup_requires', []).append('install_freedesktop')
 


### PR DESCRIPTION
I had a colleague try `pip install` this repo, and because of the `install_freedesktop` step in setup.py, it tries to install to `/usr/share/applications/`.

Honestly, `install_freedesktop` as a module is old (2015) and the projects repository is no longer active on github.

I would prefer to deprecate the install `.desktop` files, but i'm unclear on how many users might be using the desktop launcher for the application.

Building the wheel first then installing it allows the application to install, but the `.desktop` file is not valid in this case.

This should close Issue #94 .