### PR TITLE
README: add pyqt6-dev-tools to Debian deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ but it may come in handy when using the embedded IPython console.
 
 ```bash
 sudo apt-get install -y python3-pip python3-setuptools python3-wheel
-sudo apt-get install -y python3-numpy python3-pyqt6 python3-pyqt6.qtsvg git-core
+sudo apt-get install -y python3-numpy python3-pyqt6 python3-pyqt6.qtsvg pyqt6-dev-tools git-core
 python3 -m pip install git+https://github.com/DroneCAN/gui_tool@master
 ```
 


### PR DESCRIPTION
pyqtgraph imports `from PyQt6 import sip, uic` at module load time. On Debian/Ubuntu the uic submodule is split out of python3-pyqt6 into the pyqt6-dev-tools package, so without it the app crashes on startup with "ImportError: cannot import name 'uic' from 'PyQt6'".