### PR TITLE
main: Fixes an incorrectly constructed environment PATH resulting in failure to subprocess system applications

### DIFF
--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -62,7 +62,7 @@ logger.info('Spawned')
 #
 # Applying Windows-specific hacks
 #
-os.environ['PATH'] = os.environ['PATH'] + ';' + os.path.dirname(sys.executable)  # Otherwise it fails to load on Win 10
+os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.dirname(sys.executable)  # Otherwise it fails to load on Win 10
 
 #
 # Configuring multiprocessing.


### PR DESCRIPTION
While testing on Fedora 44, noticed that `_linux_parse_ip_link_show` was failing to run `ip link show`.

After investigating, it was because `/usr/bin` was being dropped off the PATH because the windows hack made the PATH look like: `/home/user/.local/bin:/home/user/bin:/usr/local/bin:/usr/bin;/usr/bin`.

That Windows PATH separator resulted in the `/usr/bin` folder not being usable on the PATH, and thus `ip link show` could not run.

We fix this by using `os.pathsep` to determine the appropriate path separator, and ensure the PATH is constructed correctly.