### PR TITLE
fix(main): keep node spin resilient to unrecognised message types

### DIFF
--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -110,6 +110,8 @@ NODE_NAME = 'org.dronecan.gui_tool'
 
 class MainWindow(QMainWindow):
     MAX_SUCCESSIVE_NODE_ERRORS = 1000
+    TRANSFER_ERROR_LOG_INTERVAL = 10        # Seconds between repeated logs of an identical transfer error
+    MAX_TRACKED_TRANSFER_ERRORS = 64        # Cap on distinct transfer-error messages tracked for throttling
 
     # noinspection PyTypeChecker,PyCallByClass,PyUnresolvedReferences
     def __init__(self, node, iface_name, iface_kwargs):
@@ -120,6 +122,8 @@ class MainWindow(QMainWindow):
 
         self._node = node
         self._successive_node_errors = 0
+        self._transfer_error_stats = {}     # Error text -> {'last_log': monotonic, 'suppressed': int}
+        self._make_frame_handling_resilient()
         self._iface_name = iface_name
 
         self._active_data_type_detector = ActiveDataTypeDetector(self._node)
@@ -559,12 +563,42 @@ class MainWindow(QMainWindow):
         w.show()
         self._node_windows[node_id] = w
 
+    def _make_frame_handling_resilient(self):
+        # dronecan's Node.spin() drains the whole RX queue and *then* runs its scheduler -- periodic
+        # NodeStatus broadcasts, outstanding-request timeouts/retries, and the node monitor's 1 Hz
+        # stale-node sweep (node_monitor registers it via node.periodic). If a single frame fails to
+        # decode, Node._recv_frame -> Transfer.from_frames raises (e.g. an unrecognised data type ID
+        # from a node using DSDL we haven't loaded, while prototyping new messages). That exception
+        # aborts the rest of the drain AND skips the scheduler poll for that spin. A message broadcast
+        # at high rate then trips nearly every 10 ms spin, so the scheduler is starved and good frames
+        # queued behind the bad one are delayed -- nodes flap in and out of the monitor and the UI
+        # stalls. Catching it up in _spin_node is too late: the damage is already done inside spin().
+        #
+        # So we wrap _recv_frame to drop an undecodable transfer in place, letting spin() finish
+        # draining the queue and run its scheduler exactly as it would for clean traffic. The raw
+        # frames remain visible in the bus monitor regardless (it taps the driver directly).
+        original_recv_frame = self._node._recv_frame
+
+        def resilient_recv_frame(raw_frame):
+            try:
+                original_recv_frame(raw_frame)
+            except dronecan.transport.TransferError as ex:
+                self._report_transfer_error(ex)
+
+        self._node._recv_frame = resilient_recv_frame
+
     def _spin_node(self):
         # We're running the node in the GUI thread.
         # This is not great, but at the moment seems like other options are even worse.
         try:
             self._node.spin(0)
             self._successive_node_errors = 0
+        except dronecan.transport.TransferError as ex:
+            # Backstop only: undecodable transfers are normally dropped inside spin() by the
+            # _recv_frame wrapper installed in _make_frame_handling_resilient(). This catches a
+            # TransferError that might surface from any other path. Benign and per-transfer, so it
+            # must NOT count towards the fatal successive-error threshold below.
+            self._report_transfer_error(ex)
         except Exception as ex:
             self._successive_node_errors += 1
 
@@ -580,6 +614,34 @@ class MainWindow(QMainWindow):
 
             logger.error(msg, exc_info=True)
             self.statusBar().showMessage(msg, 3000)
+
+    def _report_transfer_error(self, ex):
+        # Called for every undecodable transfer -- potentially at hundreds of hertz -- so the common
+        # path must stay cheap. We touch the log and status bar at most once per
+        # TRANSFER_ERROR_LOG_INTERVAL seconds per distinct error, and otherwise just tally how many
+        # identical occurrences were suppressed in between.
+        text = str(ex)
+        now = time.monotonic()
+        stat = self._transfer_error_stats.get(text)
+        if stat is None:
+            # Bound memory in the pathological case of many distinct errors (e.g. CRC mismatches
+            # embed the varying payload bytes in their message text).
+            if len(self._transfer_error_stats) >= self.MAX_TRACKED_TRANSFER_ERRORS:
+                self._transfer_error_stats.clear()
+            stat = self._transfer_error_stats[text] = {'last_log': 0.0, 'suppressed': 0}
+
+        if now - stat['last_log'] >= self.TRANSFER_ERROR_LOG_INTERVAL:
+            if stat['suppressed']:
+                logger.warning('Ignoring undecodable transfer: %s (%d more suppressed in the last %.0f s)',
+                               text, stat['suppressed'], self.TRANSFER_ERROR_LOG_INTERVAL)
+            else:
+                logger.warning('Ignoring undecodable transfer: %s', text)
+            self.statusBar().showMessage('Ignoring undecodable transfer: %s' % text,
+                                         int(self.TRANSFER_ERROR_LOG_INTERVAL * 1000))
+            stat['last_log'] = now
+            stat['suppressed'] = 0
+        else:
+            stat['suppressed'] += 1
 
     def closeEvent(self, qcloseevent):
         self._plotter_manager.close()


### PR DESCRIPTION
## Summary

The GUI tool terminates a few seconds after it starts receiving a DroneCAN message whose data type ID isn't in the loaded DSDL set, and in the lead-up the node list flaps and the UI stalls. That makes it impossible to prototype a new message on a live bus without first building its DSDL into the tool. This makes the local node tolerate unrecognised transfers instead of falling over on them.

## Problem

An unrecognised data type ID makes `Transfer.from_frames()` raise `TransferError`, and two things go wrong. First, `_spin_node` counts every such error toward the 1000-strike successive-error guard (and logs a full traceback on each 10 ms spin), so a continuously broadcast unknown message terminates the node within seconds. Second, and more subtly, `Node.spin()` drains the RX queue and then runs its scheduler, but the exception aborts the drain and skips the scheduler poll. Node-monitor liveness is scheduler-driven — the periodic stale-sweep and the outstanding-request timeouts — so at high message rates the scheduler is starved: nodes flap in and out of the monitor and the UI stalls.

## Solution

Wrap `Node._recv_frame` so an undecodable transfer is reported and dropped in place, letting `spin()` finish draining the queue and run its scheduler exactly as it does for clean traffic. The catch in `_spin_node` is kept as a backstop but no longer counts these benign per-transfer errors toward the fatal threshold. Logging is throttled to once per 10 s per distinct error with a suppressed count, so a high-rate unknown message can't flood the log. Raw frames remain visible in the bus monitor, so unknown traffic is still observable while prototyping.
