### PR TITLE
actuator panel: fix type errors

### DIFF
--- a/dronecan_gui_tool/panels/actuator_panel.py
+++ b/dronecan_gui_tool/panels/actuator_panel.py
@@ -46,7 +46,7 @@ class PercentSlider(QWidget):
         self._spinbox.setValue(0)
         self._spinbox.setDecimals(3)
         self._spinbox.setSingleStep(0.001)
-        self._spinbox.valueChanged.connect(lambda: self._slider.setValue(self._spinbox.value()*1000.0))
+        self._spinbox.valueChanged.connect(lambda: self._slider.setValue(int(self._spinbox.value()*1000.0)))
 
         self._zero_button = make_icon_button('fa6.hand', 'Zero setpoint', self, text = 'Zero', on_clicked=self.zero)
 
@@ -135,7 +135,7 @@ class ActuatorPanel(QDialog):
         self._bcast_interval.setSingleStep(0.01)
         self._bcast_interval.setValue(self.DEFAULT_INTERVAL)
         self._bcast_interval.valueChanged.connect(
-            lambda: self._bcast_timer.setInterval(self._bcast_interval.value() * 1e3))
+            lambda: self._bcast_timer.setInterval(int(self._bcast_interval.value() * 1e3)))
 
         self._stop_all = make_icon_button('fa6.hand', 'Zero all channels', self, text='Zero All',
                                           on_clicked=self._do_stop_all)


### PR DESCRIPTION
This PR fixes two type errors in the actuator panel.

Bugs caused by these errors:
* Changes to the broadcast interval input do not change the broadcast interval timer's interval value.
* Changing command value directly in the command value spinbox does not update the corresponding command value slider component.
* When changing the broadcast interval input, command value spinbox, or command value slider, a large number of errors are emitted, spamming the output.

### Traceback samples:

Broadcast interval:
```
Traceback (most recent call last):
  File "C:\Users\keith.anderson\git\gui_tool\dronecan_gui_tool\panels\actuator_panel.py", line 138, in <lambda>
    lambda: self._bcast_timer.setInterval(self._bcast_interval.value() * 1e3))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setInterval(self, msec: int): argument 1 has unexpected type 'float'
```
Slider:
```
Traceback (most recent call last):
  File "C:\Users\keith.anderson\git\gui_tool\dronecan_gui_tool\panels\actuator_panel.py", line 49, in <lambda>
    self._spinbox.valueChanged.connect(lambda: self._slider.setValue(self._spinbox.value()*1000.0))
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setValue(self, a0: int): argument 1 has unexpected type 'float'
```