### PR TITLE
main: Better Reporting of the GUI Tool Version Numbers

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,8 @@ target/
 # IDE
 .idea/
 
+# Virtual Environments
 venv/
+
+# Build Artifacts
+dronecan_gui_tool/_version_generated.py

--- a/dronecan_gui_tool/main.py
+++ b/dronecan_gui_tool/main.py
@@ -42,12 +42,23 @@ else:
 
 logging.basicConfig(stream=sys.stderr, level=logging_level,
                     format='%(asctime)s %(levelname)s %(name)s %(message)s')
-
-from .version import __version__
+try:
+    from .version import __version_tuple__
+except ModuleNotFoundError:
+    __version_tuple__ = (0, 0, 0, "unknown")
+__version__ = [x for x in __version_tuple__ if isinstance(x, int)]
 if args.version:
-    v = '.'.join(map(str, __version__))
+    metadata_parts = [x for x in __version_tuple__ if isinstance(x, str)]
+    is_clean_release = len(metadata_parts) == 0
+    is_dirty = any(".d" in part for part in metadata_parts)
+    version_info = '.'.join(map(str, __version__))
+    metadata_info = '.'.join(map(str, metadata_parts))
     print("DroneCAN GUI Tool is an application for DroneCAN bus management and diagnostics")
-    print(f"DroneCAN GUI Tool Version: {v}")
+    print(f"DroneCAN GUI Tool Version: {version_info}")
+    if not is_clean_release:
+        print(f"Development Build: {metadata_info}")
+        if is_dirty:
+            print("Warning: Built from a dirty working tree!")
     sys.exit(0)
 
 log_file = tempfile.NamedTemporaryFile(mode='w', prefix='dronecan_gui_tool-', suffix='.log', delete=False)

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -8,7 +8,42 @@
 #         Andrew Tridgell
 #
 #
-__version__ = 1, 2, 28
 
+# Note: This version is incremented after the release has been made
+__version_tuple__ = 1, 2, 28
+
+
+# Now try to import the generated version information and override the locally managed version info
+
+try:
+    from ._version_generated import __version_tuple__
+except ImportError:
+    try:
+        import subprocess
+        git_describe = subprocess.check_output(
+            ["git", "describe", "--tags", "--long", "--dirty"],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
+
+        is_dirty = git_describe.endswith("-dirty")
+        if is_dirty:
+            git_describe = git_describe[:-6] # slice off the '-dirty'
+
+        # Split from the right, because the tag itself might contain hyphens (e.g., v1.0-beta)
+        parts = git_describe.rsplit("-", 2)
+
+        if len(parts) == 3:
+            base_tag = parts[0]
+            commits_since = int(parts[1])
+            sha = parts[2]
+            __version_tuple__ += (f"source-dev{commits_since}", sha)
+            if is_dirty:
+                __version_tuple__ += ("dirty", )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        # FileNotFoundError: The 'git' executable is not installed/available
+        # CalledProcessError: The command failed (e.g., not inside a git repository)
+        print("Warning: Git is not available")
+        __version_tuple__ += ("source",)
 
 

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -9,100 +9,32 @@
 #
 #
 
-import os
-import subprocess
 import re
 
 # Note: This version is determined dynamically at build time or runtime.
 __version_tuple__ = (1, 2, 28)
 
-# 1. Try running git describe first (live git repository state)
 try:
-
-    git_describe = subprocess.check_output(
-        ["git", "describe", "--tags", "--long", "--dirty"],
-        stderr=subprocess.DEVNULL,
-        text=True,
-        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    ).strip()
-
-    is_dirty = git_describe.endswith("-dirty")
-    if is_dirty:
-        git_describe = git_describe[:-6] # slice off the '-dirty'
-
-    # Split from the right, because the tag itself might contain hyphens (e.g., v1.0-beta)
-    parts = git_describe.rsplit("-", 2)
-
-    if len(parts) == 3:
-        base_tag = parts[0]
-        commits_since = int(parts[1])
-        sha = parts[2]
-        
-        # Parse base tag into tuple (e.g., "1.2.28" -> (1, 2, 28))
-        # Remove leading 'v' if present
-        if base_tag.startswith('v'):
-            base_tag = base_tag[1:]
-        
-        tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
-        
-        __version_tuple__ = tag_parts
-        if commits_since > 0:
-            __version_tuple__ += (f"source-post{commits_since}", sha)
-        if is_dirty:
-            __version_tuple__ += ("dirty", )
-except (FileNotFoundError, subprocess.CalledProcessError):
+    # 1. Try to get the version from setuptools_scm (live git repository state)
+    from setuptools_scm import get_version
+    import os
+    _root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    _version_str = get_version(root=_root_dir, version_scheme='post-release')
+    # Parse the version string into a tuple
+    _parts = []
+    for _part in re.split(r'[-.+]', _version_str):
+        if _part:
+            try:
+                _parts.append(int(_part))
+            except ValueError:
+                _parts.append(_part)
+    __version_tuple__ = tuple(_parts)
+except Exception as e:
     # 2. Try to import the generated version information (built wheels/MSIs)
     try:
-        from ._version_generated import __version_tuple__
+        from ._version_generated import __version_tuple__  # noqa: F401
     except ImportError:
-        # 3. Fall back to reading .git_archival.txt (GitHub source ZIPs)
-        __version_tuple__ += ("unknown",)
-        
-        archival_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".git_archival.txt")
-        if os.path.isfile(archival_path):
-            with open(archival_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-            
-            # Extract node hash
-            node_match = re.search(r'^node:[ \t]*([a-f0-9]{40})$', content, re.MULTILINE)
-            # Extract describe-name
-            describe_match = re.search(r'^describe-name:[ \t]*(.+)$', content, re.MULTILINE)
-            # Extract ref-names
-            ref_match = re.search(r'^ref-names:[ \t]*(.+)$', content, re.MULTILINE)
-            
-            if node_match and not node_match.group(1).startswith('$'):
-                sha = 'g' + node_match.group(1)[:7]
-                base_tag = None
-                commits_since = 0
-
-                if describe_match and not describe_match.group(1).startswith('$'):
-                    describe_str = describe_match.group(1).strip()
-                    parts = describe_str.rsplit("-", 2)
-
-                    if len(parts) == 3 and parts[1].isdigit() and parts[2].startswith('g'):
-                        base_tag = parts[0]
-                        commits_since = int(parts[1])
-                    else:
-                        base_tag = describe_str
-
-                if not base_tag and ref_match and not ref_match.group(1).startswith('$'):
-                    refs = ref_match.group(1).split(', ')
-                    tags = [r[5:] for r in refs if r.startswith('tag: ')]
-                    if tags:
-                        base_tag = tags[0]
-                        
-                if base_tag:
-                    if base_tag.startswith('v'):
-                        base_tag = base_tag[1:]
-                        
-                    tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
-                    if tag_parts:
-                        __version_tuple__ = tag_parts
-                        if commits_since > 0:
-                            __version_tuple__ += (f"source-post{commits_since}", sha)
-                    else:
-                        __version_tuple__ += ("source", sha)
-                else:
-                    __version_tuple__ += ("source", sha)
-        else:
-            print("Warning: Git is not available and .git_archival.txt not found")
+        # 3. Fall back to the manually updated version
+        print("Warning: setuptools_scm is not available or failed with: ", e,
+              " and _version_generated.py not found. "
+              "Falling back to manual version.")

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -19,6 +19,8 @@ try:
     from setuptools_scm import get_version
     import os
     _root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if os.path.exists(os.path.join(_root_dir, '.git', 'shallow')):
+        raise Exception("Shallow clone detected, falling back to manual version")
     _version_str = get_version(root=_root_dir, version_scheme='post-release')
     # Parse the version string into a tuple
     _parts = []

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -9,17 +9,19 @@
 #
 #
 
-# Note: This version is incremented after the release has been made
-__version_tuple__ = 1, 2, 28
-
+# Note: This version is determined dynamically at build time or runtime.
+__version_tuple__ = None
 
 # Now try to import the generated version information and override the locally managed version info
-
 try:
     from ._version_generated import __version_tuple__
 except ImportError:
+    import os
+    import subprocess
+    import re
+
+    # Try running git describe first
     try:
-        import subprocess
         git_describe = subprocess.check_output(
             ["git", "describe", "--tags", "--long", "--dirty"],
             stderr=subprocess.DEVNULL,
@@ -37,13 +39,69 @@ except ImportError:
             base_tag = parts[0]
             commits_since = int(parts[1])
             sha = parts[2]
-            __version_tuple__ += (f"source-dev{commits_since}", sha)
+            
+            # Parse base tag into tuple (e.g., "1.2.28" -> (1, 2, 28))
+            # Remove leading 'v' if present
+            if base_tag.startswith('v'):
+                base_tag = base_tag[1:]
+            
+            tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
+            
+            __version_tuple__ = tag_parts
+            if commits_since > 0:
+                __version_tuple__ += (f"source-post{commits_since}", sha)
             if is_dirty:
                 __version_tuple__ += ("dirty", )
     except (FileNotFoundError, subprocess.CalledProcessError):
-        # FileNotFoundError: The 'git' executable is not installed/available
-        # CalledProcessError: The command failed (e.g., not inside a git repository)
-        print("Warning: Git is not available")
-        __version_tuple__ += ("source",)
+        # We are likely running from a downloaded GitHub archive where .git is missing.
+        # Fall back to reading .git_archival.txt
+        __version_tuple__ = (0, 0, 0, "unknown")
+        
+        archival_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.git_archival.txt')
+        if os.path.isfile(archival_path):
+            with open(archival_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            
+            # Extract node hash
+            node_match = re.search(r'^node:[ \t]*([a-f0-9]{40})$', content, re.MULTILINE)
+            # Extract describe-name
+            describe_match = re.search(r'^describe-name:[ \t]*(.+)$', content, re.MULTILINE)
+            # Extract ref-names
+            ref_match = re.search(r'^ref-names:[ \t]*(.+)$', content, re.MULTILINE)
+            
+            if node_match and not node_match.group(1).startswith('$'):
+                sha = 'g' + node_match.group(1)[:7]
+                base_tag = None
+                commits_since = 0
 
+                if describe_match and not describe_match.group(1).startswith('$'):
+                    describe_str = describe_match.group(1).strip()
+                    parts = describe_str.rsplit("-", 2)
 
+                    if len(parts) == 3 and parts[1].isdigit() and parts[2].startswith('g'):
+                        base_tag = parts[0]
+                        commits_since = int(parts[1])
+                    else:
+                        base_tag = describe_str
+
+                if not base_tag and ref_match and not ref_match.group(1).startswith('$'):
+                    refs = ref_match.group(1).split(', ')
+                    tags = [r[5:] for r in refs if r.startswith('tag: ')]
+                    if tags:
+                        base_tag = tags[0]
+                        
+                if base_tag:
+                    if base_tag.startswith('v'):
+                        base_tag = base_tag[1:]
+                        
+                    tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
+                    if tag_parts:
+                        __version_tuple__ = tag_parts
+                        if commits_since > 0:
+                            __version_tuple__ += (f"source-post{commits_since}", sha)
+                    else:
+                        __version_tuple__ = (0, 0, 0, "source", sha)
+                else:
+                    __version_tuple__ = (0, 0, 0, "source", sha)
+        else:
+            print("Warning: Git is not available and .git_archival.txt not found")

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -14,11 +14,14 @@ import re
 # Note: This version is determined dynamically at build time or runtime.
 __version_tuple__ = (1, 2, 28)
 
+import os
+
+_root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_is_source = os.path.exists(os.path.join(_root_dir, 'setup.py'))
+
 try:
     # 1. Try to get the version from setuptools_scm (live git repository state)
     from setuptools_scm import get_version
-    import os
-    _root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if os.path.exists(os.path.join(_root_dir, '.git', 'shallow')):
         raise Exception("Shallow clone detected, falling back to manual version")
     _version_str = get_version(root=_root_dir, version_scheme='post-release')
@@ -32,11 +35,16 @@ try:
                 _parts.append(_part)
     __version_tuple__ = tuple(_parts)
 except Exception as e:
-    # 2. Try to import the generated version information (built wheels/MSIs)
-    try:
-        from ._version_generated import __version_tuple__  # noqa: F401
-    except ImportError:
-        # 3. Fall back to the manually updated version
+    if not _is_source:
+        # 2. Try to import the generated version information (built wheels/MSIs)
+        try:
+            from ._version_generated import __version_tuple__  # noqa: F401
+        except ImportError:
+            # 3. Fall back to the manually updated version
+            print("Warning: setuptools_scm is not available or failed with: ", e,
+                  " and _version_generated.py not found. "
+                  "Falling back to manual version.")
+    else:
         print("Warning: setuptools_scm is not available or failed with: ", e,
-              " and _version_generated.py not found. "
+              " and running from source. "
               "Falling back to manual version.")

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -14,7 +14,7 @@ import subprocess
 import re
 
 # Note: This version is determined dynamically at build time or runtime.
-__version_tuple__ = None
+__version_tuple__ = (1, 2, 28)
 
 # 1. Try running git describe first (live git repository state)
 try:
@@ -22,8 +22,10 @@ try:
     git_describe = subprocess.check_output(
         ["git", "describe", "--tags", "--long", "--dirty"],
         stderr=subprocess.DEVNULL,
-        text=True
+        text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     ).strip()
+
     is_dirty = git_describe.endswith("-dirty")
     if is_dirty:
         git_describe = git_describe[:-6] # slice off the '-dirty'
@@ -54,7 +56,7 @@ except (FileNotFoundError, subprocess.CalledProcessError):
         from ._version_generated import __version_tuple__
     except ImportError:
         # 3. Fall back to reading .git_archival.txt (GitHub source ZIPs)
-        __version_tuple__ = (0, 0, 0, "unknown")
+        __version_tuple__ += ("unknown",)
         
         archival_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".git_archival.txt")
         if os.path.isfile(archival_path):
@@ -99,8 +101,8 @@ except (FileNotFoundError, subprocess.CalledProcessError):
                         if commits_since > 0:
                             __version_tuple__ += (f"source-post{commits_since}", sha)
                     else:
-                        __version_tuple__ = (0, 0, 0, "source", sha)
+                        __version_tuple__ += ("source", sha)
                 else:
-                    __version_tuple__ = (0, 0, 0, "source", sha)
+                    __version_tuple__ += ("source", sha)
         else:
             print("Warning: Git is not available and .git_archival.txt not found")

--- a/dronecan_gui_tool/version.py
+++ b/dronecan_gui_tool/version.py
@@ -9,55 +9,54 @@
 #
 #
 
+import os
+import subprocess
+import re
+
 # Note: This version is determined dynamically at build time or runtime.
 __version_tuple__ = None
 
-# Now try to import the generated version information and override the locally managed version info
+# 1. Try running git describe first (live git repository state)
 try:
-    from ._version_generated import __version_tuple__
-except ImportError:
-    import os
-    import subprocess
-    import re
 
-    # Try running git describe first
-    try:
-        git_describe = subprocess.check_output(
-            ["git", "describe", "--tags", "--long", "--dirty"],
-            stderr=subprocess.DEVNULL,
-            text=True
-        ).strip()
+    git_describe = subprocess.check_output(
+        ["git", "describe", "--tags", "--long", "--dirty"],
+        stderr=subprocess.DEVNULL,
+        text=True
+    ).strip()
+    is_dirty = git_describe.endswith("-dirty")
+    if is_dirty:
+        git_describe = git_describe[:-6] # slice off the '-dirty'
 
-        is_dirty = git_describe.endswith("-dirty")
+    # Split from the right, because the tag itself might contain hyphens (e.g., v1.0-beta)
+    parts = git_describe.rsplit("-", 2)
+
+    if len(parts) == 3:
+        base_tag = parts[0]
+        commits_since = int(parts[1])
+        sha = parts[2]
+        
+        # Parse base tag into tuple (e.g., "1.2.28" -> (1, 2, 28))
+        # Remove leading 'v' if present
+        if base_tag.startswith('v'):
+            base_tag = base_tag[1:]
+        
+        tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
+        
+        __version_tuple__ = tag_parts
+        if commits_since > 0:
+            __version_tuple__ += (f"source-post{commits_since}", sha)
         if is_dirty:
-            git_describe = git_describe[:-6] # slice off the '-dirty'
-
-        # Split from the right, because the tag itself might contain hyphens (e.g., v1.0-beta)
-        parts = git_describe.rsplit("-", 2)
-
-        if len(parts) == 3:
-            base_tag = parts[0]
-            commits_since = int(parts[1])
-            sha = parts[2]
-            
-            # Parse base tag into tuple (e.g., "1.2.28" -> (1, 2, 28))
-            # Remove leading 'v' if present
-            if base_tag.startswith('v'):
-                base_tag = base_tag[1:]
-            
-            tag_parts = tuple(int(x) for x in base_tag.split('.') if x.isdigit())
-            
-            __version_tuple__ = tag_parts
-            if commits_since > 0:
-                __version_tuple__ += (f"source-post{commits_since}", sha)
-            if is_dirty:
-                __version_tuple__ += ("dirty", )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        # We are likely running from a downloaded GitHub archive where .git is missing.
-        # Fall back to reading .git_archival.txt
+            __version_tuple__ += ("dirty", )
+except (FileNotFoundError, subprocess.CalledProcessError):
+    # 2. Try to import the generated version information (built wheels/MSIs)
+    try:
+        from ._version_generated import __version_tuple__
+    except ImportError:
+        # 3. Fall back to reading .git_archival.txt (GitHub source ZIPs)
         __version_tuple__ = (0, 0, 0, "unknown")
         
-        archival_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.git_archival.txt')
+        archival_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".git_archival.txt")
         if os.path.isfile(archival_path):
             with open(archival_path, 'r', encoding='utf-8') as f:
                 content = f.read()

--- a/dronecan_gui_tool/widgets/about_window.py
+++ b/dronecan_gui_tool/widgets/about_window.py
@@ -20,7 +20,7 @@ from PyQt6.QtCore import Qt, PYQT_VERSION_STR, QSize
 numeric_parts = [x for x in __version_tuple__ if isinstance(x, int)]
 metadata_parts = [x for x in __version_tuple__ if isinstance(x, str)]
 is_clean_release = len(metadata_parts) == 0
-is_dirty = any(".d" in part for part in metadata_parts)
+is_dirty = any((part == "dirty") or (".d" in part) for part in metadata_parts)
 version_info = '.'.join(map(str, numeric_parts))
 metadata_info = '.'.join(map(str, metadata_parts))
 

--- a/dronecan_gui_tool/widgets/about_window.py
+++ b/dronecan_gui_tool/widgets/about_window.py
@@ -7,21 +7,32 @@
 #
 
 import dronecan
-from ..version import __version__
+try:
+    from ..version import __version_tuple__
+except ImportError:
+    __version_tuple__ = (0, 0, 0, "unknown")
 from . import get_icon, get_app_icon
 from PyQt6.QtWidgets import QDialog, QTableWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, \
     QTableWidgetItem, QHeaderView
 from PyQt6.QtGui import QIcon
 from PyQt6.QtCore import Qt, PYQT_VERSION_STR, QSize
 
+numeric_parts = [x for x in __version_tuple__ if isinstance(x, int)]
+metadata_parts = [x for x in __version_tuple__ if isinstance(x, str)]
+is_clean_release = len(metadata_parts) == 0
+is_dirty = any(".d" in part for part in metadata_parts)
+version_info = '.'.join(map(str, numeric_parts))
+metadata_info = '.'.join(map(str, metadata_parts))
 
-ABOUT_TEXT = ('''
-<h3>DroneCAN GUI Tool v{0}</h3>
-Cross-platform application for <a href="http://dronecan.org/">DroneCAN bus</a> management and diagnostics.
+ABOUT_TEXT = (f"""
+<h3>DroneCAN GUI Tool v{version_info}</h3>
+{f"<h4>Dev Build {'(Dirty)' if is_dirty else ''}: {metadata_info}</h4>" if not is_clean_release else ""}
 
-This application is distributed under the terms of the MIT software license. The source repository and the bug \
-tracker are located at <a href="https://github.com/DroneCAN/gui_tool">https://github.com/DroneCAN/gui_tool</a>.
-'''.format('.'.join(map(str, __version__)))).strip().replace('\n', '\n<br/>')
+<p>Cross-platform application for <a href="http://dronecan.org/">DroneCAN bus</a> management and diagnostics.</p>
+
+<p>This application is distributed under the terms of the MIT software license. The source repository and the bug \
+tracker are located at <a href="https://github.com/DroneCAN/gui_tool">https://github.com/DroneCAN/gui_tool</a>.</p>
+""")
 
 
 def _list_3rd_party():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 # you need to drop setup_requires from setup.py as well.
 # https://peps.python.org/pep-0518/#rationale
 [build-system]
-requires = ["setuptools>=42",'setuptools_git>=1.0',"setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 # you need to drop setup_requires from setup.py as well.
 # https://peps.python.org/pep-0518/#rationale
 [build-system]
-requires = ["setuptools>=42",'setuptools_git>=1.0']
+requires = ["setuptools>=42",'setuptools_git>=1.0',"setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ SOURCE_DIR = os.path.abspath(os.path.dirname(__file__))
 upgrade_code = '{D5CD6E19-2545-32C7-A62A-4595B28BCDC3}'
 
 sys.path.append(os.path.join(SOURCE_DIR, PACKAGE_NAME))
+from version import __version_tuple__
 
 assert sys.version_info[0] == 3, 'Python 3 is required'
 
@@ -37,7 +38,8 @@ args = dict(
     name=PACKAGE_NAME,
     use_scm_version={
         "write_to": "dronecan_gui_tool/_version_generated.py",
-        "version_scheme": "post-release"
+        "version_scheme": "post-release",
+        "fallback_version": '.'.join(map(str, __version_tuple__[0:3]))
     },
     packages=find_packages(),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,10 @@ with open("README.md", "r", encoding = "utf-8") as fh:
 #
 args = dict(
     name=PACKAGE_NAME,
-    use_scm_version={"write_to": "dronecan_gui_tool/_version_generated.py"},
+    use_scm_version={
+        "write_to": "dronecan_gui_tool/_version_generated.py",
+        "version_scheme": "post-release"
+    },
     packages=find_packages(),
     install_requires=[
         'setuptools>=18.5',

--- a/setup.py
+++ b/setup.py
@@ -36,15 +36,9 @@ with open("README.md", "r", encoding = "utf-8") as fh:
 #
 args = dict(
     name=PACKAGE_NAME,
-    use_scm_version={
-        "write_to": "dronecan_gui_tool/_version_generated.py",
-        "version_scheme": "post-release",
-        "fallback_version": '.'.join(map(str, __version_tuple__[0:3]))
-    },
     packages=find_packages(),
     install_requires=[
         'setuptools>=18.5',
-        'setuptools-scm>=6.2',
         'dronecan>=1.0.25',
         'pyserial>=3.0',
         'pymavlink>=2.4.26',
@@ -93,6 +87,16 @@ args = dict(
     ],
     package_data={'DroneCAN_GUI_Tool': [ 'icons/*.png', 'icons/*.ico']}
 )
+
+is_shallow_clone = os.path.exists(os.path.join(SOURCE_DIR, '.git', 'shallow'))
+if is_shallow_clone:
+    args['version'] = '.'.join(map(str, __version_tuple__[0:3]))
+else:
+    args['use_scm_version'] = {
+        "write_to": "dronecan_gui_tool/_version_generated.py",
+        "version_scheme": "post-release",
+        "fallback_version": '.'.join(map(str, __version_tuple__[0:3]))
+    }
 
 if 'install' in sys.argv and (sys.platform.startswith('linux') or sys.platform.startswith('darwin')):
     # Delegating the desktop integration work to 'install_freedesktop'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ SOURCE_DIR = os.path.abspath(os.path.dirname(__file__))
 upgrade_code = '{D5CD6E19-2545-32C7-A62A-4595B28BCDC3}'
 
 sys.path.append(os.path.join(SOURCE_DIR, PACKAGE_NAME))
-from version import __version__
 
 assert sys.version_info[0] == 3, 'Python 3 is required'
 
@@ -36,10 +35,11 @@ with open("README.md", "r", encoding = "utf-8") as fh:
 #
 args = dict(
     name=PACKAGE_NAME,
-    version='.'.join(map(str, __version__)),
+    use_scm_version={"write_to": "dronecan_gui_tool/_version_generated.py"},
     packages=find_packages(),
     install_requires=[
         'setuptools>=18.5',
+        'setuptools-scm>=6.2',
         'dronecan>=1.0.25',
         'pyserial>=3.0',
         'pymavlink>=2.4.26',


### PR DESCRIPTION
This is hopefully a change for the better.

I have team members running various versions of the main branch since the last release. I cannot tell exactly which version they are running because the application only tells me what `version.py` contains, which is typically updated just before the next tag and release is about to occur.

This PR makes use of `setuptools_scm` to improve the reporting of the version number.

The current build/release process entails:
1. Change the software version in `version.py`
2. Tag the release
3. Build and generate the release artifacts

This means, for all users installing from `master` after the last release, their build "_looks_" like the most recent release, but does not indicate that it is development patches on top of the last release.

This PR aims to improve some of that reporting.

Currently outstanding:
- Version Generation Working as expected on:
  - Linux
    - [x] AppImage Generation (PR #138)
    - [x] Python Wheel Generation
    - [x] Python Run From Folder
  - Windows
    - [x] MSI Generation
    - [x] Python Run From Folder
    - [ ] Python Wheel
  - macOS
    - [x] DMG Generation
    - [x] Python Run From Folder
    - [ ] Python Wheel


All of this assumes the user has installed dronecan_gui_tool with one of the following methods:

```bash
pipx install .
python -m pip install .
uv pip install .
pipx install git+https://github.com/dronecan/gui_tool.git
python -m pip install git+https://github.com/dronecan/gui_tool.git
uv pip install git+https://github.com/dronecan/gui_tool.git
```

After which, one of the following outcomes occur...

```bash
# Release Version installed, check the version...

$> dronecan_gui_tool --version
DroneCAN GUI Tool is an application for DroneCAN bus management and diagnostics
DroneCAN GUI Tool Version: 4.3.2

# Clean Working Tree Version Installed, but not a tagged commit...
$> dronecan_gui_tool --version
DroneCAN GUI Tool is an application for DroneCAN bus management and diagnostics
DroneCAN GUI Tool Version: 1.2.28
Development Build: post43.g9f9737e40

# Dirty Working Tree Version installed, not tagged commit
$> dronecan_gui_tool --version
DroneCAN GUI Tool is an application for DroneCAN bus management and diagnostics
DroneCAN GUI Tool Version: 1.2.28
Development Build: post44.g4fba222d7.d20260724
Warning: Built from a dirty working tree!
```

Similarly, the version can be seen in the application.

Release Build:
<img width="720" height="455" alt="image" src="https://github.com/user-attachments/assets/82daba16-90ef-4976-9e57-53c32fc441f1" />

Clean Work Tree, Development Build
<img width="720" height="455" alt="image" src="https://github.com/user-attachments/assets/2a834096-4e6f-457e-bfde-5bf2851e0f02" />

Dirty Work Tree, Development Build
<img width="720" height="455" alt="Dirty Work Tree" src="https://github.com/user-attachments/assets/ff0ca90b-ffc1-4f50-b058-ef68dcca8a16" />

When locally running the build, you will now get the following:

```bash
$> ./bin/dronecan_gui_tool --version
Running from the source directory
DroneCAN GUI Tool is an application for DroneCAN bus management and diagnostics
DroneCAN GUI Tool Version: 1.2.28
Development Build: source-post45.g69793c2
```

<img width="720" height="455" alt="image" src="https://github.com/user-attachments/assets/51a512e1-ac40-4998-bfb7-8d69f9521bd3" />

I'm in the process of updating `README.md` - If this is accepted, the new Release Workflow should be updated to something like:
1. Create the Tag for the new version.
2. Push tag to repo
3. Build and release artifacts