### PR TITLE
serial_panel: allow a far side device to reconnect to the port if the connection is previously closed

### DIFF
--- a/dronecan_gui_tool/panels/serial_panel.py
+++ b/dronecan_gui_tool/panels/serial_panel.py
@@ -564,7 +564,8 @@ class serialPanel(QDialog):
                 return
 
             if buf is None or len(buf) == 0:
-                break
+                self.close_socket()
+                return
             if self.ublox_handling.isChecked():
                 # we will send the data on packet boundaries
                 self.handle_ublox_data_in(buf)
@@ -576,6 +577,8 @@ class serialPanel(QDialog):
 
     def process_tunnel(self):
         '''process data from the tunnel'''
+        if self.tunnel is None:
+            return
         while True:
             buf = self.tunnel.read(120)
             if buf is None or len(buf) == 0:


### PR DESCRIPTION
Receiving a zero-byte payload now triggers socket disconnect instead of failing silently.

Prevents dropped connections from leaving the serial passthrough unresponsive.